### PR TITLE
Added a `face_rectangles` argument to `FER.detect_emotions()` so `FER…

### DIFF
--- a/src/fer/fer.py
+++ b/src/fer/fer.py
@@ -44,6 +44,9 @@ from tensorflow.keras.models import load_model
 from fer.classes import Peltarion_Emotion_Classifier
 from fer.exceptions import InvalidImage
 
+from typing import Sequence, Tuple, Union
+NumpyRects = Union[np.ndarray, Sequence[Tuple[int, int, int, int]]]
+
 __author__ = "Justin Shenk"
 
 logging.basicConfig(
@@ -221,7 +224,7 @@ class FER(object):
             6: "neutral",
         }
 
-    def detect_emotions(self, img: np.ndarray) -> list:
+    def detect_emotions(self, img: np.ndarray, face_rectangles: NumpyRects = None) -> list:
         """
         Detects bounding boxes from the specified image with ranking of emotions.
         :param img: image to process (BGR or gray)
@@ -232,7 +235,8 @@ class FER(object):
 
         emotion_labels = self._get_labels()
 
-        face_rectangles = self.find_faces(img, bgr=True)
+        if not face_rectangles:
+            face_rectangles = self.find_faces(img, bgr=True)
 
         gray_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 


### PR DESCRIPTION
Here's a small change that allows you to pass in face locations to `detect_emotions()` if you know them in advance.

I've been feeding in faces using locations determined by a different system ( outlined [here](https://www.pyimagesearch.com/2018/02/26/face-detection-with-opencv-and-deep-learning/)) that handles profile or tilted faces a little more forgivingly than Haar cascades do, and I've been seeing many more results in live video than I was when using the default face recognition.
