### PR TITLE
Changed cascade file source

### DIFF
--- a/src/fer/fer.py
+++ b/src/fer/fer.py
@@ -86,9 +86,7 @@ class FER(object):
         self.tfserving = tfserving
 
         if cascade_file is None:
-            cascade_file = pkg_resources.resource_filename(
-                "fer", "data/haarcascade_frontalface_default.xml"
-            )
+            cascade_file = cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
 
         if mtcnn:
             try:


### PR DESCRIPTION
Changed cascade file source to overcome the "error: (-215:Assertion failed) !empty() in function 'cv::CascadeClassifier::detectMultiScale'" problem when not choosing mtcnn while performing analyze method.