### PR TITLE
tqdm progress bar bug

### DIFF
--- a/src/fer/classes.py
+++ b/src/fer/classes.py
@@ -294,8 +294,12 @@ class Video(object):
         if save_video:
             self.videowriter = self._save_video(outfile, fps, width, height)
 
+        total_frames = length
+        if frequency > 1:
+            total_frames = length/frequency
+            
         with logging_redirect_tqdm():
-            pbar = tqdm(total=length, unit="frames")
+            pbar = tqdm(total=total_frames, unit="frames")
 
         while self.cap.isOpened():
             ret, frame = self.cap.read()


### PR DESCRIPTION
If a frequency is provided, the correct progress status can be obtained by dividing the total length by the frequency.

At present, the processing is based on the actual length of the video. For instance, if I specify a frequency of 2, the processing is considered complete when 50% of the video has been processed.